### PR TITLE
Update weather.interfaces.ts to make zipcode a string

### DIFF
--- a/src/weather.interfaces.ts
+++ b/src/weather.interfaces.ts
@@ -31,7 +31,7 @@ export interface WeatherQueryParams {
     lat: number;
     lng: number;
   };
-  zipCode?: number;
+  zipCode?: string;
   units?: TemperatureScale;
   lang?: string;
 }


### PR DESCRIPTION
Currently zipcode is a number. This means you cannot pass in a zipcode that starts with a 0. Since giving the widget the zipcode is the easiest way to set the location, changing to a string makes sense. I have tested this and everything works 100% correctly when it is changed to a string.